### PR TITLE
Use webcrypto for aes-cbc segment decryption when supported

### DIFF
--- a/src/decrypter.js
+++ b/src/decrypter.js
@@ -23,7 +23,7 @@ const ntoh = function(word) {
 /**
  * Decrypt bytes using AES-128 with CBC and PKCS#7 padding.
  *
- * @param {Uint8Array} encrypted the encrypted bytes
+ * @param {Uint32Array}  encrypted the encrypted bytes
  * @param {Uint32Array} key the bytes of the decryption key
  * @param {Uint32Array} initVector the initialization vector (IV) to
  * use for the first round of CBC.
@@ -33,7 +33,7 @@ const ntoh = function(word) {
  * @see http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_.28CBC.29
  * @see https://tools.ietf.org/html/rfc2315
  */
-export const decrypt = function(encrypted, key, initVector) {
+const decryptNonNative = function(encrypted, key, initVector) {
   // word-level access to the encrypted bytes
   let encrypted32 = new Int32Array(encrypted.buffer,
                                    encrypted.byteOffset,
@@ -107,13 +107,20 @@ export const decrypt = function(encrypted, key, initVector) {
  * function
  *
  * @param {Uint8Array} encrypted the encrypted bytes
- * @param {Uint32Array} key the bytes of the decryption key
+ * @param {Uint8Array} key the bytes of the decryption key
  * @param {Uint32Array} initVector the initialization vector (IV) to
  * @param {Function} done the function to run when done
  * @class Decrypter
  */
 export class Decrypter {
   constructor(encrypted, key, initVector, done) {
+    let view = new DataView(key.buffer);
+    let littleEndianKey = new Uint32Array([
+      view.getUint32(0),
+      view.getUint32(4),
+      view.getUint32(8),
+      view.getUint32(12)
+    ]);
     let step = Decrypter.STEP;
     let encrypted32 = new Int32Array(encrypted.buffer);
     let decrypted = new Uint8Array(encrypted.byteLength);
@@ -123,7 +130,7 @@ export class Decrypter {
 
     // split up the encryption job and do the individual chunks asynchronously
     this.asyncStream_.push(this.decryptChunk_(encrypted32.subarray(i, i + step),
-                                              key,
+                                              littleEndianKey,
                                               initVector,
                                               decrypted));
     for (i = step; i < encrypted32.length; i += step) {
@@ -132,7 +139,7 @@ export class Decrypter {
                                     ntoh(encrypted32[i - 2]),
                                     ntoh(encrypted32[i - 1])]);
       this.asyncStream_.push(this.decryptChunk_(encrypted32.subarray(i, i + step),
-                                                key,
+                                                littleEndianKey,
                                                 initVector,
                                                 decrypted));
     }
@@ -158,14 +165,108 @@ export class Decrypter {
    */
   decryptChunk_(encrypted, key, initVector, decrypted) {
     return function() {
-      let bytes = decrypt(encrypted, key, initVector);
+      // decryptNonNative must be a separate function (not a method or
+      // static method on Decrypter) else IE10 will crash.
+      let bytes = decryptNonNative(encrypted, key, initVector);
 
       decrypted.set(bytes, encrypted.byteOffset);
     };
   }
 }
 
-export default {
-  Decrypter,
-  decrypt
+/**
+ * Get a consistent crypto.subtle across various browsers.
+ *
+ * @return {WebCrypto Object}
+ */
+const getWebCrypto = function() {
+  // IE11 uses this prefix, but with an out of date version of the
+  // spec that doesn't use Promises, and doesn't have native Promises
+  // either, thus we fall back to the non-native decryption. Edge is
+  // up to spec.
+  if (window.msCrypto) {
+    return null;
+  }
+
+  let _crypto = window ? window.crypto : crypto;
+
+  if (!_crypto) {
+    return null;
+  }
+
+  // We shouldn't need to worry about Safari (which does HLSe
+  // natively) but we use this for completeness.
+  if (_crypto.webkitSubtle) {
+    _crypto.subtle = _crypto.webkitSubtle;
+  }
+
+  return _crypto.subtle ? _crypto : null;
 };
+
+/**
+ * Decrypt bytes using AES-128 with CBC and PKCS#7 padding.
+ *
+ * @param {Uint8Array} encrypted the encrypted bytes
+ * @param {Uint8Array} key the bytes of the decryption key
+ * @param {Uint32Array} iv the initialization vector (IV) to
+ * use for the first round of CBC.
+ * @param {Function} done callback that takes a Uint8Array
+ *
+ * @see http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+ * @see http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_.28CBC.29
+ * @see https://tools.ietf.org/html/rfc2315
+ */
+const decryptWithWebCrypto = function(encrypted, key, iv, done) {
+  let crypto = getWebCrypto();
+  let algorithm = {name: 'AES-CBC', iv};
+  let extractable = true;
+  let usages = ['decrypt'];
+
+  let keyPromise = crypto.subtle.importKey('raw', key, algorithm, extractable, usages);
+
+  return keyPromise.then(function(importedKey) {
+    return crypto.subtle.decrypt(algorithm, importedKey, encrypted);
+  }).catch(function(rejection) {
+    return done(null, new Uint8Array());
+  }).then(function(plaintextArrayBuffer) {
+    return done(null, new Uint8Array(plaintextArrayBuffer));
+  });
+};
+
+/**
+ * Decrypt bytes using AES-128 with CBC and PKCS#7 padding.
+ *
+ * @param {Uint8Array} encrypted the encrypted bytes
+ * @param {Uint8Array} key the bytes of the decryption key
+ * @param {Uint32Array} iv the initialization vector (IV) to
+ * use for the first round of CBC.
+ * @return {Promise} that resolves with a Uint8Array the decrypted bytes
+ *
+ * @see http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+ * @see http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_.28CBC.29
+ * @see https://tools.ietf.org/html/rfc2315
+ */
+const decryptWithDecrypter = function(encrypted, key, iv, done) {
+  return new Decrypter(encrypted, key, iv, done);
+};
+
+/**
+ * Decrypt bytes using AES-128 with CBC and PKCS#7 padding.
+ * Chooses webcrypto or JS implementation where available.
+ *
+ * @param {Uint8Array} encrypted: the encrypted bytes
+ * @param {Uint8Array} key: the bytes of the decryption key
+ * @param {Uint32Array} iv: the initialization vector (IV) to
+ * use for the first round of CBC.
+ *
+ * @see http://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+ * @see http://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Cipher_Block_Chaining_.28CBC.29
+ * @see https://tools.ietf.org/html/rfc2315
+ */
+export const decrypt = function(encrypted, key, iv, done) {
+  let decryptionMethod = getWebCrypto() ? decryptWithWebCrypto : decryptWithDecrypter;
+
+  return decryptionMethod(encrypted, key, iv, done);
+};
+
+export default decrypt;

--- a/test/decrypter.test.js
+++ b/test/decrypter.test.js
@@ -1,6 +1,5 @@
 // see docs/hlse.md for instructions on how test data was generated
 import QUnit from 'qunit';
-import {unpad} from 'pkcs7';
 import sinon from 'sinon';
 import {decrypt, Decrypter, AsyncStream} from '../src';
 
@@ -14,10 +13,19 @@ const stringFromBytes = function(bytes) {
   return result;
 };
 
+const bytesToASCIIString = function(bytes) {
+  return String.fromCharCode.apply(null, new Uint8Array(bytes));
+};
+
 QUnit.module('Decryption');
-QUnit.test('decrypts a single AES-128 with PKCS7 block', function() {
-  let key = new Uint32Array([0, 0, 0, 0]);
-  let initVector = key;
+
+QUnit.test('decrypts a single AES-128 with PKCS7 block', function(assert) {
+  let done = assert.async();
+
+  assert.expect(1);
+
+  let key = new Uint8Array(16);
+  let iv = key;
   // the string "howdy folks" encrypted
   let encrypted = new Uint8Array([
     0xce, 0x90, 0x97, 0xd0,
@@ -26,14 +34,21 @@ QUnit.test('decrypts a single AES-128 with PKCS7 block', function() {
     0x82, 0xa8, 0xf0, 0x67
   ]);
 
-  QUnit.deepEqual('howdy folks',
-                  stringFromBytes(unpad(decrypt(encrypted, key, initVector))),
-                  'decrypted with a byte array key'
-  );
+  // Run native WebCrypto when available.
+  decrypt(encrypted, key, iv, function(err, result) {
+    if (err) {
+      QUnit.notOk(true, 'Non-null error.');
+    }
+    QUnit.deepEqual(bytesToASCIIString(result),
+                    'howdy folks',
+                    'decrypted with a byte array key'
+                   );
+    done();
+  });
 });
 
-QUnit.test('decrypts multiple AES-128 blocks with CBC', function() {
-  let key = new Uint32Array([0, 0, 0, 0]);
+QUnit.test('decrypts multiple AES-128 blocks with CBC', function(assert) {
+  let key = new Uint8Array(16);
   let initVector = key;
   // the string "0123456789abcdef01234" encrypted
   let encrypted = new Uint8Array([
@@ -47,32 +62,28 @@ QUnit.test('decrypts multiple AES-128 blocks with CBC', function() {
     0xa9, 0x54, 0xc2, 0x45,
     0xe9, 0x4e, 0x29, 0xb3
   ]);
+  let done = assert.async();
 
-  QUnit.deepEqual('0123456789abcdef01234',
-                  stringFromBytes(unpad(decrypt(encrypted, key, initVector))),
-                  'decrypted multiple blocks');
+  assert.expect(1);
+
+  // Runs native WebCrypto when available.
+  decrypt(encrypted, key, initVector, function(err, result) {
+    if (err) {
+      QUnit.notOk(true, 'Non-null error.');
+    }
+    QUnit.deepEqual(stringFromBytes(result),
+                    '0123456789abcdef01234',
+                    'decrypted multiple blocks'
+                   );
+    done();
+  });
 });
 
-QUnit.test(
-'verify that the deepcopy works by doing two decrypts in the same test',
-function() {
-  let key = new Uint32Array([0, 0, 0, 0]);
+QUnit.test('decrypts a full segment', function(assert) {
+  let key = new Uint8Array(16);
   let initVector = key;
-  // the string "howdy folks" encrypted
-  let pkcs7Block = new Uint8Array([
-    0xce, 0x90, 0x97, 0xd0,
-    0x08, 0x46, 0x4d, 0x18,
-    0x4f, 0xae, 0x01, 0x1c,
-    0x82, 0xa8, 0xf0, 0x67
-  ]);
-
-  QUnit.deepEqual('howdy folks',
-                  stringFromBytes(unpad(decrypt(pkcs7Block, key, initVector))),
-                  'decrypted with a byte array key'
-  );
-
-// the string "0123456789abcdef01234" encrypted
-  let cbcBlocks = new Uint8Array([
+  // the string "0123456789abcdef01234" encrypted
+  let encrypted = new Uint8Array([
     0x14, 0xf5, 0xfe, 0x74,
     0x69, 0x66, 0xf2, 0x92,
     0x65, 0x1c, 0x22, 0x88,
@@ -83,11 +94,109 @@ function() {
     0xa9, 0x54, 0xc2, 0x45,
     0xe9, 0x4e, 0x29, 0xb3
   ]);
+  let done = assert.async();
 
-  QUnit.deepEqual('0123456789abcdef01234',
-                  stringFromBytes(unpad(decrypt(cbcBlocks, key, initVector))),
-                  'decrypted multiple blocks');
+  assert.expect(1);
 
+  // Runs native WebCrypto when available.
+  decrypt(encrypted, key, initVector, function(err, result) {
+    if (err) {
+      QUnit.notOk(true, 'Non-null error.');
+    }
+    QUnit.deepEqual(stringFromBytes(result),
+                    '0123456789abcdef01234',
+                    'decrypted multiple blocks'
+                   );
+    done();
+  });
+});
+
+QUnit.test(
+  'verify that the deepcopy works by doing two decrypts in the same test',
+  function(assert) {
+    assert.expect(2);
+
+    let done = assert.async(2);
+    let key = new Uint8Array(16);
+    let initVector = key;
+
+    // the string "howdy folks" encrypted
+    let pkcs7Block = new Uint8Array([
+      0xce, 0x90, 0x97, 0xd0,
+      0x08, 0x46, 0x4d, 0x18,
+      0x4f, 0xae, 0x01, 0x1c,
+      0x82, 0xa8, 0xf0, 0x67
+    ]);
+
+    // Runs native WebCrypto when available.
+    decrypt(pkcs7Block, key, initVector, function(err, result) {
+      if (err) {
+        QUnit.notOk(true, 'Non-null error.');
+      }
+      QUnit.deepEqual(stringFromBytes(result),
+                      'howdy folks',
+                      'decrypted with a byte array key'
+                     );
+      done();
+    });
+
+    // the string "0123456789abcdef01234" encrypted
+    let cbcBlocks = new Uint8Array([
+      0x14, 0xf5, 0xfe, 0x74,
+      0x69, 0x66, 0xf2, 0x92,
+      0x65, 0x1c, 0x22, 0x88,
+      0xbb, 0xff, 0x46, 0x09,
+
+      0x0b, 0xde, 0x5e, 0x71,
+      0x77, 0x87, 0xeb, 0x84,
+      0xa9, 0x54, 0xc2, 0x45,
+      0xe9, 0x4e, 0x29, 0xb3
+    ]);
+
+    // Runs native WebCrypto when available.
+    decrypt(cbcBlocks, key, initVector, function(err, result) {
+      if (err) {
+        QUnit.notOk(true, 'Non-null error.');
+      }
+      QUnit.deepEqual(stringFromBytes(result),
+                      '0123456789abcdef01234',
+                      'decrypted multiple blocks'
+                     );
+      done();
+    });
+  }
+);
+
+QUnit.test('asynchronously decrypts a 4-word block', function(assert) {
+  assert.expect(1);
+
+  let done = assert.async();
+  let key = new Uint8Array(16);
+  let initVector = new Uint32Array(4);
+  // the string "howdy folks" encrypted
+  let encrypted = new Uint8Array([0xce, 0x90, 0x97, 0xd0,
+                                  0x08, 0x46, 0x4d, 0x18,
+                                  0x4f, 0xae, 0x01, 0x1c,
+                                  0x82, 0xa8, 0xf0, 0x67]);
+  /* eslint-disable no-unused-vars */
+
+  // Runs non-native JavaScript AES-CBC decryption always, even if
+  // WebCrypto is available.
+  let decrypter = new Decrypter(encrypted,
+                                key,
+                                initVector,
+                                function(err, result) {
+                                  if (err) {
+                                    QUnit.notOk(true, 'Non-null error.');
+                                  }
+                                  QUnit.deepEqual(
+                                    stringFromBytes(result),
+                                    'howdy folks',
+                                    'decrypts and unpads the result'
+                                  );
+                                  done();
+                                });
+  /* eslint-enable no-unused-vars */
 });
 
 QUnit.module('Incremental Processing', {
@@ -139,39 +248,14 @@ QUnit.module('Incremental Decryption', {
   }
 });
 
-QUnit.test('asynchronously decrypts a 4-word block', function() {
-  let key = new Uint32Array([0, 0, 0, 0]);
-  let initVector = key;
-  // the string "howdy folks" encrypted
-  let encrypted = new Uint8Array([0xce, 0x90, 0x97, 0xd0,
-                                  0x08, 0x46, 0x4d, 0x18,
-                                  0x4f, 0xae, 0x01, 0x1c,
-                                  0x82, 0xa8, 0xf0, 0x67]);
-  let decrypted;
-  let decrypter = new Decrypter(encrypted,
-                                key,
-                                initVector,
-                                function(error, result) {
-                                  if (error) {
-                                    throw new Error(error);
-                                  }
-                                  decrypted = result;
-                                });
-
-  QUnit.ok(!decrypted, 'asynchronously decrypts');
-  this.clock.tick(decrypter.asyncStream_.delay * 2);
-
-  QUnit.ok(decrypted, 'completed decryption');
-  QUnit.deepEqual('howdy folks',
-                  stringFromBytes(decrypted),
-                  'decrypts and unpads the result');
-});
-
 QUnit.test('breaks up input greater than the step value', function() {
   let encrypted = new Int32Array(Decrypter.STEP + 4);
   let done = false;
+
+  // Runs non-native JavaScript AES-CBC decryption always, even if
+  // WebCrypto is available.
   let decrypter = new Decrypter(encrypted,
-                                new Uint32Array(4),
+                                new Uint8Array(16),
                                 new Uint32Array(4),
                                 function() {
                                   done = true;


### PR DESCRIPTION
If webcrypto is supported, the spec requires Promises to be available as well, so we use Promises in that branch. Otherwise it is the same SJCL-based Decrypter implementation as before, just slightly reorganized.
