### PR TITLE
chore: update vhs-utils dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,9 +1579,9 @@
       }
     },
     "@videojs/vhs-utils": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-3.0.5.tgz",
-      "integrity": "sha512-PKVgdo8/GReqdx512F+ombhS+Bzogiofy1LgAj4tN8PfdBx3HSS7V5WfJotKTqtOWGwVfSWsrYN/t09/DSryrw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
+      "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "global": "^4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,13 +1579,12 @@
       }
     },
     "@videojs/vhs-utils": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.0.0.tgz",
-      "integrity": "sha512-xJp7Yd4jMLwje2vHCUmi8MOUU76nxiwII3z4Eg3Ucb+6rrkFVGosrXlMgGnaLjq724j3wzNElRZ71D/CKrTtxg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
+      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
       "requires": {
         "@babel/runtime": "^7.12.5",
-        "global": "^4.4.0",
-        "url-toolkit": "^2.2.1"
+        "global": "^4.4.0"
       }
     },
     "JSONStream": {
@@ -8712,11 +8711,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "url-toolkit": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/url-toolkit/-/url-toolkit-2.2.5.tgz",
-      "integrity": "sha512-mtN6xk+Nac+oyJ/PrI7tzfmomRVNFIWKUbG8jdYFt52hxbiReFAXIjYskvu64/dvuW71IcB7lV8l0HvZMac6Jg=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/vhs-utils": "^4.0.0",
+    "@videojs/vhs-utils": "^4.1.1",
     "global": "^4.4.0",
     "pkcs7": "^1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.12.5",
-    "@videojs/vhs-utils": "^3.0.5",
+    "@videojs/vhs-utils": "^4.0.0",
     "global": "^4.4.0",
     "pkcs7": "^1.0.4"
   },


### PR DESCRIPTION
## Description

update @videojs/vhs-utils to version ~4.0.0~ 4.1.1

refers https://github.com/videojs/video.js/issues/8491